### PR TITLE
Merge: Allow to disable battery light when in DND mode [1/2]

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -3476,11 +3476,17 @@ public final class Settings {
          */
         public static final String BATTERY_LIGHT_FULL_COLOR = "battery_light_full_color";
 
-	/**
+        /**
          * What color to use for the battery LED while charging - really full (100%)
          * @hide
          */
         public static final String BATTERY_LIGHT_REALLY_FULL_COLOR = "battery_light_really_full_color";
+
+        /**
+         * Whether to show battery light when DND mode is active
+         * @hide
+         */
+        public static final String BATTERY_LIGHT_ALLOW_ON_DND = "battery_light_allow_on_dnd";
 
         /**
          * Show pointer location on screen?

--- a/services/core/java/com/android/server/BatteryService.java
+++ b/services/core/java/com/android/server/BatteryService.java
@@ -162,6 +162,10 @@ public final class BatteryService extends SystemService {
     private int mBatteryReallyFullARGB;
     private boolean mMultiColorLed;
 
+    //Battery light on DND
+    private boolean mAllowBatteryLightOnDnd;
+    private boolean mIsDndActive;
+
     private boolean mSentLowBatteryBroadcast = false;
 
     public BatteryService(Context context) {
@@ -872,7 +876,7 @@ public final class BatteryService extends SystemService {
 
             final int level = mBatteryProps.batteryLevel;
             final int status = mBatteryProps.batteryStatus;
-            if (!mLightEnabled) {
+            if (!mLightEnabled || (mIsDndActive && !mAllowBatteryLightOnDnd)) {
                 // No lights if explicitly disabled
                 mBatteryLight.turnOff();
             } else if (level < mLowBatteryWarningLevel) {
@@ -1007,6 +1011,12 @@ public final class BatteryService extends SystemService {
                 resolver.registerContentObserver(
                         Settings.System.getUriFor(Settings.System.BATTERY_LIGHT_REALLY_FULL_COLOR),
                         false, this, UserHandle.USER_ALL);
+                resolver.registerContentObserver(
+                        Settings.System.getUriFor(Settings.System.BATTERY_LIGHT_ALLOW_ON_DND),
+                        false, this, UserHandle.USER_ALL);
+                resolver.registerContentObserver(
+                        Settings.Global.getUriFor(Settings.Global.ZEN_MODE),
+                        false, this, UserHandle.USER_ALL);
             }
 
             update();
@@ -1027,6 +1037,13 @@ public final class BatteryService extends SystemService {
             // Low battery pulse
             mLedPulseEnabled = Settings.System.getInt(resolver,
                         Settings.System.BATTERY_LIGHT_PULSE, 0) != 0;
+
+            // DND battery light
+            mAllowBatteryLightOnDnd = Settings.System.getInt(resolver,
+                    Settings.System.BATTERY_LIGHT_ALLOW_ON_DND, 1) == 1;
+            mIsDndActive = Settings.Global.getInt(resolver,
+                    Settings.Global.ZEN_MODE, Settings.Global.ZEN_MODE_OFF)
+                    != Settings.Global.ZEN_MODE_OFF;
 
             // Light colors
             mBatteryLowARGB = Settings.System.getInt(resolver,


### PR DESCRIPTION
the battery led can be annoying during night or when you play
a game with a connected charger.

Change-Id: I70e9ee1261b97c7b4baf4506cb4098ea550a27f6