### PR TITLE
Merge from DU

### DIFF
--- a/services/core/java/com/android/server/NativeDaemonConnector.java
+++ b/services/core/java/com/android/server/NativeDaemonConnector.java
@@ -24,11 +24,13 @@ import android.os.Looper;
 import android.os.Message;
 import android.os.PowerManager;
 import android.os.SystemClock;
+import android.os.SystemProperties;
 import android.util.LocalLog;
 import android.util.Slog;
 
 import com.android.internal.annotations.VisibleForTesting;
 import com.android.internal.util.Preconditions;
+import com.android.server.power.ShutdownThread;
 import com.google.android.collect.Lists;
 
 import java.io.FileDescriptor;
@@ -136,6 +138,12 @@ final class NativeDaemonConnector implements Runnable, Handler.Callback, Watchdo
                 listenToSocket();
             } catch (Exception e) {
                 loge("Error in NativeDaemonConnector: " + e);
+                String shutdownAct = SystemProperties.get(
+                        ShutdownThread.SHUTDOWN_ACTION_PROPERTY, "");
+                if (shutdownAct != null && shutdownAct.length() > 0) {
+                    // The device is in middle of shutdown.
+                    break;
+                }
                 SystemClock.sleep(5000);
             }
         }


### PR DESCRIPTION
Symptom:
System_server crashed due to unsolved "netd" service.

Root cause:
Init intentionally killed services when shutdown was triggered.
NativeDaemonConnector unnecessarily tried to reconnect the killed
daemon and NetworkManagemantService got a callback of connection.
Finally, NetworkManagemantService failed to get netd service and it
crashed with NPE.

Solution:
Do not retry connecting to the target native daemon when the device
is in the middle of shutdown.

Bug: 64237349
Change-Id: I2514cdc47b3eea785b5ffe5bd8bb27609bcc1726